### PR TITLE
fix a divide by 0 when comparing 0 and 0

### DIFF
--- a/R/reproCheck.r
+++ b/R/reproCheck.r
@@ -93,16 +93,21 @@ reproCheck <- function(reportedValue,
 
     obtainedValue <- as.numeric(obtainedValue) # ensure obtained value is numeric
     reportedValue <- as.numeric(reportedValue) # ensure reported value is numeric
-
-    pe <- ((abs(obtainedValue - reportedValue))/abs(reportedValue))*100 # calculate percentage error
-
-    # identify comparison outcome based on amount of percentage error
-    if(pe >= 10){
-      comparisonOutcome <- "MAJOR_ERROR"
-    }else if(pe > 0 & pe < 10){
-      comparisonOutcome <- "MINOR_ERROR"
-    }else{
+    
+    if(reportedValue == 0 & obtainedValue == 0){ # in the case both are zero, then it's a match.
       comparisonOutcome <- "MATCH"
+      pe <- 0
+    }else{
+      pe <- ((abs(obtainedValue - reportedValue))/abs(reportedValue))*100 # calculate percentage error
+      
+      # identify comparison outcome based on amount of percentage error
+      if(pe >= 10){
+        comparisonOutcome <- "MAJOR_ERROR"
+      }else if(pe > 0 & pe < 10){
+        comparisonOutcome <- "MINOR_ERROR"
+      }else{
+        comparisonOutcome <- "MATCH"
+      }
     }
 
     if(isP){ # if we are comparing p values


### PR DESCRIPTION
I had an error with the current version of reproCheck such that e.g
`reproCheck('0', 0, valueType='other')`
would have a divide-by-zero error.

I've patched it so that if both the reported and obtained values are zero, then the check counts as a match with percentage error of zero.